### PR TITLE
Add config for gradual moon phase darkness transitions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: HaXrDEV
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - Minecraft version: [e.g. 1.21.1]
+ - Mod version [e.g. 1.1.3]
+
+**Additional context**
+Add any other context about the problem here.

--- a/src/client/java/grondag/darkness/Darkness.java
+++ b/src/client/java/grondag/darkness/Darkness.java
@@ -97,7 +97,8 @@ public class Darkness {
                 if (angle > 0.25f && angle < 0.75f) {
                     final float oldWeight = Math.max(0, (Math.abs(angle - 0.5f) - 0.2f)) * 20;
                     final float moon = CONFIG.ignoreMoonPhase() ? 0 : world.getMoonBrightness();
-                    return Mth.lerp(oldWeight * oldWeight * oldWeight, moon * moon, 1f);
+                    final float moonBrightness = CONFIG.gradualMoonPhaseDarkness() ? moon : moon * moon;
+                    return Mth.lerp(oldWeight * oldWeight * oldWeight, moonBrightness, 1f);
                 } else {
                     return 1;
                 }

--- a/src/main/java/grondag/darkness/config/DarknessConfigModel.java
+++ b/src/main/java/grondag/darkness/config/DarknessConfigModel.java
@@ -24,5 +24,6 @@ public class DarknessConfigModel {
     public double darkEndFog = 0.0;
     public boolean blockLightOnly = false;
     public boolean ignoreMoonPhase = false;
+    public boolean gradualMoonPhaseDarkness = false;
     public boolean requireMod = false;
 }

--- a/src/main/resources/assets/darkness/lang/en_us.json
+++ b/src/main/resources/assets/darkness/lang/en_us.json
@@ -3,6 +3,7 @@
     "text.config.darkness.option.blockLightOnly": "Affect Block Light Only",
     "text.config.darkness.help.blockLightOnly": "Areas lit by sky will not be fully dark",
     "text.config.darkness.option.ignoreMoonPhase": "Ignore Moon Phase",
+    "text.config.darkness.option.gradualMoonPhaseDarkness": "Gradual Moon Phase Darkness Transitions",
     "text.config.darkness.help.ignore_moon_phase": "Night is truly dark even when the moon is full",
     "text.config.darkness.option.darkOverworld": "Dark Overworld",
     "text.config.darkness.help.darkOverworld": "Enable in Overworld",


### PR DESCRIPTION
Hi, I was wondering if you'd be willing to accept this pull request to add a config option to enable more gradual darkness transitions between full moon and new moon?
I personally prefer a more gradual linear transition from bright to dark so that there is more contrast between the brighter and darker phases of the moon.

Currently moon brightness is squared so it goes from:
Night 1 (full moon) -> 1.0 x 1.0 = 1.0 brightness
Night 2 (3/4 full)     -> .75 x .75 = 0.5625 brightness
Night 3 (1/2 moon) -> 0.5 x 0.5 = 0.25 brightness
Night 4 (1/4 full)     -> .25 x .25 = 0.0625 brightness
Night 5 (new moon)-> 0 x 0      = 0 brightness
...

I added a config option to enable linear transitions so it would be
Night 1 -> 1.0 brightness
Night 2 -> 0.75 brightness
Night 3 -> 0.5 brightness
Night 4 -> 0.25 brightness
Night 5 -> 0 brightness
...

Here's a comparison of what it looks like without and with the config option enabled:
![true-dark-gradual-comparison](https://github.com/user-attachments/assets/96e94b17-6f5c-42aa-a542-94a53d3d9674)
