### PR TITLE
1.21.2 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: HaXrDEV
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - Minecraft version: [e.g. 1.21.1]
+ - Mod version [e.g. 1.1.3]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Create Release
 on:
   release:
     types: [published]
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -99,3 +100,19 @@ jobs:
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
           name: v${{github.ref_name}} for Fabric 1.21.1
           files: 'versions/1.21.1/build/libs/!(*-@(dev|sources|javadoc|all)).jar'
+
+      - name: Publish-1.21.2-Fabric-Curseforge
+        uses: Kir-Antipov/mc-publish@v3.3.0
+        with:
+          curseforge-id: 906926
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          name: v${{github.ref_name}} for Fabric 1.21.2
+          files: 'versions/1.21.2/build/libs/!(*-@(dev|sources|javadoc|all)).jar'
+
+      - name: Publish-1.21.2-Fabric-Modrinth
+        uses: Kir-Antipov/mc-publish@v3.3.0
+        with:
+          modrinth-id: Pf8PJBb5
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          name: v${{github.ref_name}} for Fabric 1.21.2
+          files: 'versions/1.21.2/build/libs/!(*-@(dev|sources|javadoc|all)).jar'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,2 @@
-- Fixed *Dark Nether Fog* & *Dark End Fog* options not working.
-- Changed *Dark Nether Fog* & *Dark End Fog* option fields into sliders.
-- Changed description in Mod Menu.
-- Switched to use Stonecutter toolchain for development.
+- 1.21.2 support.
+- Bumped Fabric loader to 0.16.7.

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ mod.mc_targets=[VERSIONED]
 mod.loader=[VERSIONED]
 
 # Global dependencies
-deps.fabric_loader=0.15.11
+deps.fabric_loader=0.16.7
 
 # Versioned dependencies
 # deps.yarn_build=[VERSIONED]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ stonecutter {
     centralScript = "build.gradle.kts"
 
     shared {
-        versions("1.20.1", "1.20.2", "1.20.4", "1.20.6", "1.21.1")
+        versions("1.20.1", "1.20.2", "1.20.4", "1.20.6", "1.21.1", "1.21.2")
     }
     create(rootProject)
 }

--- a/src/client/java/grondag/darkness/mixin/client/MixinGameRenderer.java
+++ b/src/client/java/grondag/darkness/mixin/client/MixinGameRenderer.java
@@ -35,6 +35,12 @@ import net.minecraft.client.renderer.LightTexture;
 import grondag.darkness.Darkness;
 import grondag.darkness.LightmapAccess;
 
+
+//? if >=1.21.2 {
+import net.minecraft.util.profiling.Profiler;
+//?}
+
+
 //? if >=1.21 {
 import net.minecraft.client.DeltaTracker;
 //?} else if <=1.20.4 {
@@ -60,14 +66,24 @@ public class MixinGameRenderer {
         final LightmapAccess lightmap = (LightmapAccess) lightTexture;
 
         if (lightmap.darkness_isDirty()) {
-            minecraft.getProfiler().push("lightTex");
+            //? if >=1.21.2 {
+            Profiler.get().push("lightTex");
+            //?} else {
+            /*minecraft.getProfiler().push("lightTex");
+            *///?}
+
             //? if >=1.21 {
             Darkness.updateLuminance(deltaTracker.getGameTimeDeltaTicks(), minecraft, (GameRenderer) (Object) this,
                 lightmap.darkness_prevFlicker());
             //?} else {
             /*Darkness.updateLuminance(tickDelta, minecraft, (GameRenderer) (Object) this, lightmap.darkness_prevFlicker());
             *///?}
-            minecraft.getProfiler().pop();
+
+            //? if >=1.21.2 {
+            Profiler.get().pop();
+            //?} else {
+            /*minecraft.getProfiler().pop();
+             *///?}
         }
     }
 }

--- a/src/client/java/grondag/darkness/mixin/client/MixinLightTexture.java
+++ b/src/client/java/grondag/darkness/mixin/client/MixinLightTexture.java
@@ -50,8 +50,13 @@ public class MixinLightTexture implements LightmapAccess {
         if (Darkness.enabled && lightPixels != null) {
             for (int b = 0; b < 16; b++) {
                 for (int s = 0; s < 16; s++) {
-                    final int color = Darkness.darken(lightPixels.getPixelRGBA(b, s), b, s);
+                    //? if >=1.21.2 {
+                    final int color = Darkness.darken(lightPixels.getPixel(b, s), b, s);
+                    lightPixels.setPixel(b, s, color);
+                    //?} else {
+                    /*final int color = Darkness.darken(lightPixels.getPixelRGBA(b, s), b, s);
                     lightPixels.setPixelRGBA(b, s, color);
+                     *///?}
                 }
             }
         }

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("fabric-loom") version "1.7-SNAPSHOT" apply false
     //id("dev.kikugie.j52j") version "1.0.2" apply false // Enables asset processing by writing json5 files
 }
-stonecutter active "1.21.1" /* [SC] DO NOT EDIT */
+stonecutter active "1.21.2" /* [SC] DO NOT EDIT */
 
 // Builds every version into `build/libs/{mod.version}/`
 stonecutter registerChiseled tasks.register("chiseledBuild", stonecutter.chiseled) {
@@ -31,28 +31,29 @@ stonecutter configureEach {
 // GitHub Action Stuff
 var releaseText = StringBuilder()
 
-releaseText.append("name: Create Release\n")
+releaseText.append("""name: Create Release
+on:
+  release:
+    types: [published]
 
-releaseText.append("on:\n")
-releaseText.append("  release:\n")
-releaseText.append("    types: [published]\n")
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
 
-releaseText.append("jobs:\n")
-releaseText.append("  build:\n")
-releaseText.append("    runs-on: ubuntu-latest\n")
-releaseText.append("    steps:\n")
-releaseText.append("      - name: checkout repository\n")
-releaseText.append("        uses: actions/checkout@v2\n\n")
-releaseText.append("      - name: setup jdk 21\n")
-releaseText.append("        uses: actions/setup-java@v1\n")
-releaseText.append("        with:\n")
-releaseText.append("          java-version: 21\n\n")
-releaseText.append("      - name: make gradle wrapper executable\n")
-releaseText.append("        run: chmod +x ./gradlew\n\n")
-releaseText.append("      - name: build\n")
-releaseText.append("        run: ./gradlew chiseledBuild\n")
+      - name: setup jdk 21
+        uses: actions/setup-java@v1
+        with:
+          java-version: 21
 
+      - name: make gradle wrapper executable
+        run: chmod +x ./gradlew
 
+      - name: build
+        run: ./gradlew chiseledBuild
+""")
 
 
 var actionFile = file("$rootDir/.github/workflows/publish.yml")

--- a/versions/1.21.2/gradle.properties
+++ b/versions/1.21.2/gradle.properties
@@ -2,7 +2,7 @@ deps.yarn_build=3
 deps.fabric_api=0.106.1+1.21.2
 deps.apoli=2.12.0-alpha.12+mc.1.21.x
 deps.origins=1.13.0-alpha.9+mc.1.21.x
-deps.owo_lib=0.12.15+1.21
+deps.owo_lib=0.12.16+1.21.2
 deps.mod_menu=PcJvQYqu
 
 mod.mc_dep=1.21.2

--- a/versions/1.21.2/gradle.properties
+++ b/versions/1.21.2/gradle.properties
@@ -1,0 +1,11 @@
+deps.yarn_build=3
+deps.fabric_api=0.106.1+1.21.2
+deps.apoli=2.12.0-alpha.12+mc.1.21.x
+deps.origins=1.13.0-alpha.9+mc.1.21.x
+deps.owo_lib=0.12.15+1.21
+deps.mod_menu=PcJvQYqu
+
+mod.mc_dep=1.21.2
+mod.mc_title=1.21.2
+mod.mc_targets=1.21.2
+mod.loader=fabric


### PR DESCRIPTION
Mojang has made major changes to the LightTexture class in 1.21.2, making the update process more challenging.

#### Stuff to do:

- [ ] Rewrite LightTexture mixin.